### PR TITLE
Switch MCP server to Streamable HTTP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,15 +194,17 @@ python3 mcp_server.py
 }
 ```
 
-### Remote Setup (SSE over HTTPS)
+### Remote Setup (Streamable HTTP over HTTPS)
 
-To expose the MCP server to remote clients over the network:
+To expose the MCP server to remote clients (n8n, Claude Desktop, Cursor, etc.) over the network:
 
-#### 1. Start the MCP server in SSE mode
+#### 1. Start the MCP server in HTTP mode
 
 ```bash
-python3 mcp_server.py --sse --host 127.0.0.1 --port 8808
+python3 mcp_server.py --http --host 127.0.0.1 --port 8808
 ```
+
+This starts the Streamable HTTP transport at `/mcp` — the current MCP standard (SSE is deprecated).
 
 #### 2. Create a systemd service (keeps it running)
 
@@ -210,14 +212,14 @@ Create `/etc/systemd/system/monsoft-scrapper-mcp.service`:
 
 ```ini
 [Unit]
-Description=Monsoft Scrapper MCP Server (SSE)
+Description=Monsoft Scrapper MCP Server
 After=network.target
 
 [Service]
 Type=simple
 User=root
 WorkingDirectory=/path/to/scrapling-kit
-ExecStart=/path/to/venv/bin/python3 /path/to/scrapling-kit/mcp_server.py --sse --host 127.0.0.1 --port 8808
+ExecStart=/path/to/venv/bin/python3 /path/to/scrapling-kit/mcp_server.py --http --host 127.0.0.1 --port 8808
 Restart=always
 RestartSec=5
 Environment=PYTHONUNBUFFERED=1
@@ -248,7 +250,7 @@ scrapper-mcp.yourdomain.com {
 }
 ```
 
-> **Important:** The `header_up Host` directive is required. The MCP SSE server validates the Host header, and without this rewrite it will reject requests with a 421 error.
+> **Important:** The `header_up Host` directive is required. The MCP server validates the Host header, and without this rewrite it will reject requests.
 
 ```bash
 sudo systemctl reload caddy
@@ -269,7 +271,7 @@ server {
         proxy_set_header Host localhost:8808;
         proxy_set_header X-Real-IP $remote_addr;
 
-        # Required for SSE
+        # Required for streaming responses
         proxy_http_version 1.1;
         proxy_set_header Connection '';
         proxy_buffering off;
@@ -287,11 +289,17 @@ If using Cloudflare, set the record to **DNS only** (no proxy) — Caddy/nginx h
 
 #### 5. Connect remote clients
 
+**n8n MCP Client node:**
+- Endpoint: `https://scrapper-mcp.yourdomain.com/mcp`
+- Server Transport: **HTTP Streamable**
+- Authentication: None
+
+**Claude Desktop / Cursor / other MCP clients:**
 ```json
 {
     "mcpServers": {
         "monsoft-scrapper": {
-            "url": "https://scrapper-mcp.yourdomain.com/sse"
+            "url": "https://scrapper-mcp.yourdomain.com/mcp"
         }
     }
 }
@@ -301,9 +309,9 @@ If using Cloudflare, set the record to **DNS only** (no proxy) — Caddy/nginx h
 
 ```
 python3 mcp_server.py                              # stdio (local)
-python3 mcp_server.py --sse --port 8808            # SSE (remote)
-python3 mcp_server.py --streamable-http            # Streamable HTTP
-python3 mcp_server.py --sse --host 0.0.0.0         # Bind all interfaces (no reverse proxy)
+python3 mcp_server.py --http --port 8808            # Streamable HTTP (recommended for remote)
+python3 mcp_server.py --sse --port 8808             # SSE (legacy, deprecated)
+python3 mcp_server.py --http --host 0.0.0.0         # Bind all interfaces (no reverse proxy)
 ```
 
 ## Usage Statistics

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -256,18 +256,18 @@ def main():
         description="MCP server for Monsoft Scrapper",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""Examples:
-  python3 mcp_server.py                          # stdio (local)
-  python3 mcp_server.py --sse --port 8808        # SSE (remote)
-  python3 mcp_server.py --streamable-http        # Streamable HTTP
-  python3 mcp_server.py --sse --host 0.0.0.0     # Bind all interfaces""",
+  python3 mcp_server.py                              # stdio (local)
+  python3 mcp_server.py --http --port 8808            # Streamable HTTP (recommended for remote)
+  python3 mcp_server.py --sse --port 8808             # SSE (legacy, deprecated)
+  python3 mcp_server.py --http --host 0.0.0.0         # Bind all interfaces""",
+    )
+    parser.add_argument(
+        "--http", action="store_true",
+        help="Run with Streamable HTTP transport (recommended for remote clients)",
     )
     parser.add_argument(
         "--sse", action="store_true",
-        help="Run with SSE transport (HTTP server for remote clients)",
-    )
-    parser.add_argument(
-        "--streamable-http", action="store_true",
-        help="Run with Streamable HTTP transport",
+        help="Run with SSE transport (legacy, deprecated by MCP spec)",
     )
     parser.add_argument(
         "--host", default="127.0.0.1",
@@ -275,7 +275,7 @@ def main():
     )
     parser.add_argument(
         "--port", type=int, default=8808,
-        help="Port for SSE/HTTP transport (default: 8808)",
+        help="Port for HTTP/SSE transport (default: 8808)",
     )
 
     args = parser.parse_args()
@@ -284,14 +284,14 @@ def main():
     mcp.settings.host = args.host
     mcp.settings.port = args.port
 
-    if args.sse:
-        print(f"🚀 MCP server starting (SSE) on {args.host}:{args.port}", file=sys.stderr)
-        print(f"   SSE endpoint: http://{args.host}:{args.port}/sse", file=sys.stderr)
-        mcp.run(transport="sse")
-    elif args.streamable_http:
+    if args.http:
         print(f"🚀 MCP server starting (Streamable HTTP) on {args.host}:{args.port}", file=sys.stderr)
         print(f"   Endpoint: http://{args.host}:{args.port}/mcp", file=sys.stderr)
         mcp.run(transport="streamable-http")
+    elif args.sse:
+        print(f"🚀 MCP server starting (SSE) on {args.host}:{args.port}", file=sys.stderr)
+        print(f"   SSE endpoint: http://{args.host}:{args.port}/sse", file=sys.stderr)
+        mcp.run(transport="sse")
     else:
         # stdio — no output to stderr except from tools
         mcp.run(transport="stdio")


### PR DESCRIPTION
## Why
SSE is deprecated by the MCP spec (2025-03-26). n8n marks it as "Server Sent Events (Deprecated)" and only offers HTTP Streamable as the current option.

## Changes
- New `--http` flag (recommended) replaces `--streamable-http`
- Endpoint: `/mcp` instead of `/sse`
- `--sse` still works for legacy clients
- Updated systemd service to use `--http`
- Updated README with n8n-specific setup instructions

## n8n Config
- Endpoint: `https://scrapper-mcp.davincilabs.cloud/mcp`
- Server Transport: **HTTP Streamable**
- Authentication: None

## Testing
- ✅ Streamable HTTP working via curl (JSON-RPC initialize)
- ✅ MCP Python client connected over HTTPS
- ✅ 4 tools listed and callable
- ✅ Server running as systemd service